### PR TITLE
Headless selenimu for remote rigor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,12 +24,12 @@ workflows:
           filters:
             branches:
               only: master
-      #- deploy-docker:
-      #    requires:
-      #      - package-docker
-      #    filters:
-      #      branches:
-      #        only: master
+      - deploy-docker:
+          requires:
+            - package-docker
+          filters:
+            branches:
+              only: master
       - dark-deploy:
           requires:
             - package-jar

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
 			<plugin>
 				<groupId>com.google.cloud.tools</groupId>
 				<artifactId>jib-maven-plugin</artifactId>
-				<version>0.9.6</version>
+				<version>0.9.7</version>
 				<configuration>
 					<to>
 						<image>registry.hub.docker.com/eddiewebb/blueskygreenbuilds-demo</image>

--- a/src/main/resources/application-it.properties
+++ b/src/main/resources/application-it.properties
@@ -9,3 +9,6 @@ vcap.application.name=blueskygreenbuilds-test
 sauce.platform=Windows 10
 sauce.version=57.0
 sauce.browser=chrome
+
+
+test-groups=integration-tests

--- a/src/main/resources/application-it.properties
+++ b/src/main/resources/application-it.properties
@@ -9,6 +9,3 @@ vcap.application.name=blueskygreenbuilds-test
 sauce.platform=Windows 10
 sauce.version=57.0
 sauce.browser=chrome
-
-
-test-groups=integration-tests

--- a/src/test/java/com/edwardawebb/circleci/demo/it/AbstractWebIT.java
+++ b/src/test/java/com/edwardawebb/circleci/demo/it/AbstractWebIT.java
@@ -12,6 +12,7 @@ import org.openqa.selenium.remote.RemoteWebDriver;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.embedded.LocalServerPort;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.IfProfileValue;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.net.MalformedURLException;

--- a/src/test/java/com/edwardawebb/circleci/demo/it/HeadlessFlowTests.java
+++ b/src/test/java/com/edwardawebb/circleci/demo/it/HeadlessFlowTests.java
@@ -1,6 +1,5 @@
 package com.edwardawebb.circleci.demo.it;
 
-import com.edwardawebb.circleci.demo.DemoApplication;
 import org.junit.*;
 import org.junit.runner.RunWith;
 
@@ -10,7 +9,6 @@ import com.gargoylesoftware.htmlunit.html.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.StringContains.containsString;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.annotation.IfProfileValue;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 

--- a/src/test/java/com/edwardawebb/circleci/demo/it/HeadlessFlowTests.java
+++ b/src/test/java/com/edwardawebb/circleci/demo/it/HeadlessFlowTests.java
@@ -1,0 +1,50 @@
+package com.edwardawebb.circleci.demo.it;
+
+import com.edwardawebb.circleci.demo.DemoApplication;
+import org.junit.*;
+import org.junit.runner.RunWith;
+
+import com.gargoylesoftware.htmlunit.*;
+import com.gargoylesoftware.htmlunit.html.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.StringContains.containsString;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.annotation.IfProfileValue;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+
+/**
+ * This is not a local test, but is intended to be paired with Rigor to execute remote tests. It will be ignored thorugh normal test lifecycle.
+ *  To run explicitly, use ./mvnw -Dtest=HeadlessFlowTests test -Dtest-groups=rigor -DbaseURL="http://dark.blueskygreenbuilds.com"
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@IfProfileValue(name="test-groups", values={"rigor"})
+public class HeadlessFlowTests {
+
+    private String baseURL;
+
+    private WebClient webClient;
+
+    @Before
+    public void setup() {
+        baseURL = System.getProperty("baseURL","http://example.com");
+        System.err.println("Using: " + baseURL);
+        webClient = new WebClient();
+    }
+
+    @After
+    public void close() {
+        webClient.close();
+    }
+
+    @Test
+    public void homePageHtmlUnit() throws Exception {
+        HtmlPage currentPage = webClient.getPage(baseURL);
+        Assert.assertEquals("Blue Sky, Green Builds", currentPage.getTitleText());
+        HtmlAnchor link = (HtmlAnchor) currentPage.getElementById("car-btn-1");
+        HtmlPage result = link.click();
+        assertThat( result.getBody().getTextContent(), containsString("Start Today"));
+    }
+}


### PR DESCRIPTION
New test class allows

`./mvnw -Dtest=HeadlessFlowTests test -Dtest-groups=rigor -DbaseURL="http://dark.blueskygreenbuilds.com"`

to test against staging deployments.

Also re-attempts jib 0.9.7 with credential fix