### PR TITLE
Replace jobs with orbs to reduce config size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,27 +2,55 @@ version: 2.1
 orbs:
   cloudfoundry: circleci/cloudfoundry@0.1.12
   slack:        circleci/slack@0.1.0
+  saucelabs:    saucelabs/sauce-connect@1.0.1
+  maven:        circleci/maven@0.0.2
+
 
 workflows:
   version: 2
   build_deploy:
     jobs:
-      - unit-test
-      - test-chrome:
+      - maven/test:
+          name: "Unit Test"
+          command: 'package -B test'
+
+      - saucelabs/with_proxy:
+          name: "Chrome Tests"
           requires:
-            - unit-test
-      - test-ie:
+            - "Unit Test"
+          tunnel_identifier: chrome
+          steps:
+            - maven/with_cache:
+                steps:
+                  - run: ./mvnw verify -B -Dspring.profiles.active=it -Dsauce.tunnel="chrome" 
+
+      - saucelabs/with_proxy:
+          name: "IE Tests"
           requires:
-            - unit-test
-      - static_code_analysis:
+            - "Unit Test"
+          tunnel_identifier: ie
+          steps:
+            - maven/with_cache:
+                steps:
+                  - run: ./mvnw verify -B -Dspring.profiles.active=it -Dsauce.version=11.103 -Dsauce.tunnel="ie" -Dsauce.browser="internet explorer" 
+     
+      - maven/test:
+          name: "Static Analysis"
+          command: 'clean org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar 
+                     -Dsonar.host.url=https://sonarcloud.io 
+                     -Dsonar.organization=circleci-demo 
+                     -Dsonar.login=${SONAR_KEY} 
+                     -Dsonar.branch.name=${CIRCLE_BRANCH}'
           requires:
-            - unit-test
+            - "Unit Test"
+
       - package-jar:
           requires:
-            - unit-test
+            - "Unit Test"
           filters:
             branches:
               only: master
+
       - cloudfoundry/dark_deploy:
           requires:
             - package-jar
@@ -41,15 +69,17 @@ workflows:
             - slack/notify:
                 message: "The latest inventory is ready to ship, please review/approve ASAP! https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"
                 mentions: UA8FDUL8P
+
       - hold:
           type: approval
           requires:
             - cloudfoundry/dark_deploy
-            - test-ie
-            - test-chrome
+            - "IE Tests"
+            - "Chrome Tests"
           filters:
             branches:
               only: master
+              
       - cloudfoundry/live_deploy:
           requires:
             - hold
@@ -64,163 +94,15 @@ workflows:
 
 
 jobs:
-  unit-test:
-    resource_class: medium
-    docker:
-      - image: circleci/openjdk@sha256:76e4d88773f25ac52c3f0c63bf63b8e346ce799fbfe3691566f03d987795c70f
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - blueskygreenbuilds-mvn-V2-{{ checksum "pom.xml" }}
-            - blueskygreenbuilds-mvn-V2
-
-      - run: mvn --batch-mode dependency:go-offline 
-      - run:
-          name: Build and *unit* test
-          command: |
-            mvn test -B  #run your tests
-
-
-      - save_cache:
-          paths:
-            - ~/.m2
-          key: blueskygreenbuilds-mvn-V2-{{ checksum "pom.xml" }}
-
-      - store_test_results:
-          path: target/surefire-reports
-
-
-  test-chrome:
-    resource_class: large
-    docker:
-      - image: circleci/openjdk@sha256:76e4d88773f25ac52c3f0c63bf63b8e346ce799fbfe3691566f03d987795c70f
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - blueskygreenbuilds-mvn-V2-{{ checksum "pom.xml" }}
-            - blueskygreenbuilds-mvn-V2
-
-      - run: mvn dependency:go-offline
-
-      - run:
-          name: Start SauceLabs Tunnel (required if testing on CircleCI container)
-          command: |
-            : ${SAUCELABS_USER:?"Required Env Variable not found!"}
-            : ${SAUCELABS_KEY:?"Required Env Variable not found!"}
-            curl https://saucelabs.com/downloads/sc-4.4.12-linux.tar.gz -o saucelabs.tar.gz
-            tar -xzf saucelabs.tar.gz
-            cd sc-*
-            # startup saucelabs tunnel as background task (its a blocking command)
-            bin/sc -u ${SAUCELABS_USER} -k ${SAUCELABS_KEY} -i chrome &
-            #wait for sauce tunnel up to 1 minute
-            wget --retry-connrefused --no-check-certificate -T 60 localhost:4445
-
-      - run:
-          name: Build and Integration test
-          command: |
-            mvn verify -B -Dspring.profiles.active=it -Dsauce.browser=chrome  -Dsauce.tunnel="chrome" #package and run your browser tests
-            killall sc #kill saucelabs tunnel
-      - save_cache:
-          paths:
-           - ~/.m2
-          key: blueskygreenbuilds-mvn-V2-{{ checksum "pom.xml" }}
-
-
-  test-ie:
-    resource_class: large
-    docker:
-      - image: circleci/openjdk@sha256:76e4d88773f25ac52c3f0c63bf63b8e346ce799fbfe3691566f03d987795c70f
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - blueskygreenbuilds-mvn-V2-{{ checksum "pom.xml" }}
-            - blueskygreenbuilds-mvn-V2
-
-      - run: mvn dependency:go-offline
-
-      - run:
-          name: Start SauceLabs Tunnel (required if testing on CircleCI container)
-          command: |
-            : ${SAUCELABS_USER:?"Required Env Variable not found!"}
-            : ${SAUCELABS_KEY:?"Required Env Variable not found!"}
-            curl https://saucelabs.com/downloads/sc-4.4.12-linux.tar.gz -o saucelabs.tar.gz
-            tar -xzf saucelabs.tar.gz
-            cd sc-*
-            # startup saucelabs tunnel as background task (its a blocking command)
-            bin/sc -u ${SAUCELABS_USER} -k ${SAUCELABS_KEY} -i ie &
-            #wait for sauce tunnel up to 1 minute
-            wget --retry-connrefused --no-check-certificate -T 60 localhost:4445
-
-      - run:
-          name: Build and Integration test
-          command: |
-            mvn verify -B -Dspring.profiles.active=it -Dsauce.version=11.103 -Dsauce.tunnel="ie" -Dsauce.browser="internet explorer" #package and run your browser tests
-            killall sc #kill saucelabs tunnel
-
-
-      - save_cache:
-          paths:
-           - ~/.m2
-          key: blueskygreenbuilds-mvn-V2-{{ checksum "pom.xml" }}
-
-  static_code_analysis:
-    resource_class: xlarge
-    docker:
-      - image: circleci/openjdk@sha256:76e4d88773f25ac52c3f0c63bf63b8e346ce799fbfe3691566f03d987795c70f
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - blueskygreenbuilds-mvn-V2-{{ checksum "pom.xml" }}
-            - blueskygreenbuilds-sonar-mvn-{{ checksum "pom.xml" }}
-      - restore_cache:
-          key: blueskygreenbuilds-sonar
-      - run:
-          name: Static Code Analysis (SonarQube)
-          command: |
-            mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar \
-                 -Dsonar.host.url=https://sonarcloud.io \
-                 -Dsonar.organization=circleci-demo \
-                 -Dsonar.login=${SONAR_KEY} \
-                 -Dsonar.branch.name=${CIRCLE_BRANCH}
-      - save_cache:
-          paths:
-           - ~/.sonar/cache
-          key: blueskygreenbuilds-sonar
-      - save_cache:
-          paths:
-           - ~/.m2
-          key: blueskygreenbuilds-sonar-mvn-{{ checksum "pom.xml" }}
-
-
-
-
   package-jar:
     docker:
       - image: circleci/openjdk@sha256:76e4d88773f25ac52c3f0c63bf63b8e346ce799fbfe3691566f03d987795c70f
     working_directory: ~/repo
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - blueskygreenbuilds-mvn-V2-{{ checksum "pom.xml" }}
-            - blueskygreenbuilds-mvn-V2
-      - run: mvn dependency:go-offline
-      - save_cache:
-          paths:
-           - ~/.m2
-          key: blueskygreenbuilds-mvn-V2-{{ checksum "pom.xml" }}
-      - run:
-          name: Package Jar
-          command: |
-            mvn package -B -DskipTests=true
+      - maven/with_cache:
+          steps: 
+            - run: mvn package -B -DskipTests=true
       - run:
           name: Copy deployment artifacts to workspace
           command: |

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.5.10.RELEASE</version>
+		<version>1.5.18.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
@@ -53,6 +53,14 @@
 
 	<build>
 		<plugins>
+			<plugin>		
+				<groupId>org.apache.maven.plugins</groupId>
+			    <artifactId>maven-surefire-plugin</artifactId>
+			    <version>2.22.1</version>
+		        <configuration>
+		          <useSystemClassLoader>false</useSystemClassLoader>
+		        </configuration>
+			</plugin>	
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
@@ -60,10 +68,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>2.21.0</version>
-
+				<version>2.22.1</version>
 				<configuration>
 					<classesDirectory>${project.build.outputDirectory}</classesDirectory>
+		          	<useSystemClassLoader>false</useSystemClassLoader>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION

use maven orb for unit tests

orb'd all maven jobs except package which needs custom steps

orb'd sonarqube job

hard codes surefire and failsafe versions with ForkedBootLoader fix